### PR TITLE
Show actual transfer speed in the browser speed test

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -42,18 +42,21 @@ window.onload = function() {
     const action = isWrite ? 'write' : 'read';
     const dataToSend = isWrite ? writeData : readData;
     return async function() {
-      console.time(action);
-      for (let i=0; i<5; ++i) {
-        console.time('while');
-        console.time('send');
+      const start = window.performance.now();
+      let totalBytes = 0;
+
+      const NUM_ITER = 5;
+      log(`Running ${NUM_ITER} ${action} tests:`);
+
+      for (let i=0; i<NUM_ITER; ++i) {
+        log(`  ${i+1}`);
         const receivedData = await send(dataToSend);
-        console.timeEnd('send');
-        const message = `Finished (send ${dataToSend.length} bytes, receive ${receivedData.length} bytes)`;
-        log(message);
-        console.log(message);
-        console.timeEnd('while');
+        // only one of those is non-zero
+        totalBytes += dataToSend.length + receivedData.length;
       }
-      console.timeEnd(action);
+
+      const time = window.performance.now() - start;
+      log(`Done in ${time}ms, speed: ${(totalBytes / time / 1000.0).toFixed(2)}MBps`);
     }
   }
 

--- a/browser.js
+++ b/browser.js
@@ -6,8 +6,9 @@ const writeData = new Uint8Array(16*1024*1024);
 
 function log(text) {
   let logWindow = document.getElementById("logWindow");
-  logWindow.appendChild(document.createTextNode(text));
+  const child = logWindow.appendChild(document.createTextNode(text));
   logWindow.appendChild(document.createElement("br"));
+  return child;
 }
 
 function defaultOnMessage(e) {
@@ -46,17 +47,21 @@ window.onload = function() {
       let totalBytes = 0;
 
       const NUM_ITER = 5;
-      log(`Running ${NUM_ITER} ${action} tests:`);
+      const progress = log(`Running ${NUM_ITER} ${action} tests: `);
 
       for (let i=0; i<NUM_ITER; ++i) {
-        log(`  ${i+1}`);
+        progress.nodeValue += '.';
+
         const receivedData = await send(dataToSend);
         // only one of those is non-zero
         totalBytes += dataToSend.length + receivedData.length;
       }
 
       const time = window.performance.now() - start;
-      log(`Done in ${time}ms, speed: ${(totalBytes / time / 1000.0).toFixed(2)}MBps`);
+
+      progress.nodeValue += ' done';
+
+      log(`Elapsed: ${time}ms, average speed: ${(totalBytes / time / 1000.0).toFixed(2)}MBps`);
     }
   }
 

--- a/browser.js
+++ b/browser.js
@@ -47,22 +47,49 @@ window.onload = function() {
       const progress = log(`Running ${NUM_ITER} ${action} tests: `);
 
       const start = window.performance.now();
-      let totalBytes = 0;
 
+      // compute the mean and the standard deviation on the fly using the
+      // algorithm from TAoCP Vol 2, section 4.2.2.
+      let speedMin, speedMax, lastM, lastS;
 
       for (let i=0; i<NUM_ITER; ++i) {
         progress.nodeValue += '.';
 
+        const startThis = window.performance.now();
+
         const receivedData = await send(dataToSend);
+
+        const timeThis = window.performance.now() - startThis;
+
         // only one of those is non-zero
-        totalBytes += dataToSend.length + receivedData.length;
+        const bytesXfered = dataToSend.length + receivedData.length;
+
+        const speedThis = bytesXfered / 1000.0 / timeThis;
+
+        if (i == 0) {
+          speedMin =
+          speedMax = speedThis;
+
+          lastM = speedThis;
+          lastS = 0;
+        } else {
+          if (speedThis < speedMin)
+            speedMin = speedThis;
+          if (speedThis > speedMax)
+            speedMax = speedThis;
+
+          const oldM = lastM;
+          lastM += (speedThis - oldM)/(i + 1);
+          lastS += (speedThis - oldM)*(speedThis - lastM);
+        }
       }
 
       const time = window.performance.now() - start;
 
       progress.nodeValue += ' done';
 
-      log(`Elapsed: ${time}ms, average speed: ${(totalBytes / time / 1000.0).toFixed(2)}MBps`);
+      const f2 = (x) => x.toFixed(2);
+      log(`Elapsed: ${time}ms, avg speed: ${f2(lastM)}MBps, std dev ${f2(Math.sqrt(lastS/(NUM_ITER - 1)))},  min/max: ${f2(speedMin)}/${f2(speedMax)}`);
     }
   }
 

--- a/browser.js
+++ b/browser.js
@@ -43,11 +43,12 @@ window.onload = function() {
     const action = isWrite ? 'write' : 'read';
     const dataToSend = isWrite ? writeData : readData;
     return async function() {
+      const NUM_ITER = 5;
+      const progress = log(`Running ${NUM_ITER} ${action} tests: `);
+
       const start = window.performance.now();
       let totalBytes = 0;
 
-      const NUM_ITER = 5;
-      const progress = log(`Running ${NUM_ITER} ${action} tests: `);
 
       for (let i=0; i<NUM_ITER; ++i) {
         progress.nodeValue += '.';


### PR DESCRIPTION
Make it simpler to compare it with the results of C++ tests.

---

Any reason not to do it like this? Why do we need `console.time[End]`?